### PR TITLE
API6-120 :zap: perf: Melhoria no tempo de resposta

### DIFF
--- a/src/routes/review_route.py
+++ b/src/routes/review_route.py
@@ -458,7 +458,7 @@ def word_frequency():
         state_param = request.args.get('state')
 
         # Obtém a frequência das palavras usando a função do repositório
-        word_frequency_result = calculate_word_frequency(feeling=feeling_param, state=state_param)
+        word_frequency_result = cached_calculate_word_frequency(feeling=feeling_param, state=state_param)
         
         # Converte a lista de tuplas para um dicionário
         word_frequency_dict = dict(word_frequency_result)


### PR DESCRIPTION
Aqui, cached_calculate_word_frequency é uma versão da função calculate_word_frequency decorada com lru_cache. Isso significa que os resultados dessa função serão armazenados em cache, tornando as próximas consultas com os mesmos argumentos mais rápidas, já que os resultados serão recuperados do cache em vez de recalculados.